### PR TITLE
Update culling strike for poe2

### DIFF
--- a/HealthBar.cs
+++ b/HealthBar.cs
@@ -156,7 +156,7 @@ public class HealthBar
         if (!AllSettings.HasCullingStrike)
             return false;
 
-        float cullingMultiplier = 1.0f + (AllSettings.CullingThreshhold / 100f);
+        float cullingMultiplier = 1.0f + (AllSettings.CullingThreshold / 100f);
 
         return Type switch
         {

--- a/HealthBar.cs
+++ b/HealthBar.cs
@@ -78,7 +78,7 @@ public class HealthBar
             if (IsHidden(Entity))
                 return Color.LightGray;
 
-            if (HpPercent * 100 <= AllSettings.CullPercent)
+            if (ShouldDrawCullingStrikeIndicator())
                 return Settings.CullableColor;
 
             return Settings.LifeColor;
@@ -150,5 +150,19 @@ public class HealthBar
 
             EhpHistory.Enqueue((DateTime.UtcNow, hp));
         }
+    }
+    internal bool ShouldDrawCullingStrikeIndicator()
+    {
+        if (!AllSettings.HasCullingStrike)
+            return false;
+
+        return Type switch
+        {
+            CreatureType.Normal => HpPercent <= 0.30f,
+            CreatureType.Magic => HpPercent <= 0.20f,
+            CreatureType.Rare => HpPercent <= 0.10f,
+            CreatureType.Unique => HpPercent <= 0.05f,
+            _ => false
+        };
     }
 }

--- a/HealthBar.cs
+++ b/HealthBar.cs
@@ -156,12 +156,14 @@ public class HealthBar
         if (!AllSettings.HasCullingStrike)
             return false;
 
+        float cullingMultiplier = 1.0f + (AllSettings.CullingThreshhold / 100f);
+
         return Type switch
         {
-            CreatureType.Normal => HpPercent <= 0.30f,
-            CreatureType.Magic => HpPercent <= 0.20f,
-            CreatureType.Rare => HpPercent <= 0.10f,
-            CreatureType.Unique => HpPercent <= 0.05f,
+            CreatureType.Normal => HpPercent <= 0.30f * cullingMultiplier,
+            CreatureType.Magic => HpPercent <= 0.20f * cullingMultiplier,
+            CreatureType.Rare => HpPercent <= 0.10f * cullingMultiplier,
+            CreatureType.Unique => HpPercent <= 0.05f * cullingMultiplier,
             _ => false
         };
     }

--- a/HealthBarsSettings.cs
+++ b/HealthBarsSettings.cs
@@ -39,8 +39,13 @@ public class HealthBarsSettings : ISettings
     public RangeNode<int> DrawDistanceLimit { get; set; } = new(133, 0, 1000);
     public RangeNode<int> ShowMinionOnlyWhenBelowHp { get; set; } = new(50, 1, 100);
     public RangeNode<int> DpsEstimateDuration { get; set; } = new(2000, 500, 10000);
-
+    [Menu("Culling Strike settings", 100)]
+    public EmptyNode CullingStrike { get; set; }
+    [Menu("Has Culling Strike","You have a source of Culling Strike such as from a passive or support gem", 100)]
     public ToggleNode HasCullingStrike { get; set; } = new(false);
+    [ConditionalDisplay(nameof(HasCullingStrike), true)]
+    [Menu("Culling Strike Threshhold", "If you have Culling the Hordes or some other threshhold increase", 100)]
+    public RangeNode<int> CullingThreshhold { get; set; } = new(0, 0, 300);
 
     public ColorNode CombatDamageColor { get; set; } = Color.Red;
     public ColorNode CombatHealColor { get; set; } = Color.Green;

--- a/HealthBarsSettings.cs
+++ b/HealthBarsSettings.cs
@@ -44,8 +44,8 @@ public class HealthBarsSettings : ISettings
     [Menu("Has Culling Strike","You have a source of Culling Strike such as from a passive or support gem", 100)]
     public ToggleNode HasCullingStrike { get; set; } = new(false);
     [ConditionalDisplay(nameof(HasCullingStrike), true)]
-    [Menu("Culling Strike Threshhold", "If you have Culling the Hordes or some other threshhold increase", 100)]
-    public RangeNode<int> CullingThreshhold { get; set; } = new(0, 0, 300);
+    [Menu("Culling Strike Threshold", "If you have Culling the Hordes or some other threshold increase", 100)]
+    public RangeNode<int> CullingThreshold { get; set; } = new(0, 0, 300);
 
     public ColorNode CombatDamageColor { get; set; } = Color.Red;
     public ColorNode CombatHealColor { get; set; } = Color.Green;

--- a/HealthBarsSettings.cs
+++ b/HealthBarsSettings.cs
@@ -39,8 +39,8 @@ public class HealthBarsSettings : ISettings
     public RangeNode<int> DrawDistanceLimit { get; set; } = new(133, 0, 1000);
     public RangeNode<int> ShowMinionOnlyWhenBelowHp { get; set; } = new(50, 1, 100);
     public RangeNode<int> DpsEstimateDuration { get; set; } = new(2000, 500, 10000);
-    public RangeNode<int> CullPercent { get; set; } = new(10, 0, 100);
 
+    public ToggleNode HasCullingStrike { get; set; } = new(false);
 
     public ColorNode CombatDamageColor { get; set; } = Color.Red;
     public ColorNode CombatHealColor { get; set; } = Color.Green;


### PR DESCRIPTION
Culling strike health percentage is now decided by monster rarity

<30% for normal
<20% for magic
<10% for rare
<5% for unique

updating code to reflect this change

![image](https://github.com/user-attachments/assets/f5237fc4-8b5d-499c-94ee-3b80826c2d98)

EDIT:

* Added a Culling Strike Threshold slider for users who get 'Cull the Hordes' or similar.
![image](https://github.com/user-attachments/assets/42c98cc1-4b42-4d76-a141-791975b08a3d)

